### PR TITLE
make the activation of the conda env optional …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,5 +34,17 @@ CONTAINER_CONDA_ENVS_DIR=/opt/conda/envs
 # assemble everything:
 CONTAINER_MOUNTS=/netscratch:/netscratch,/ds:/ds:ro,"$HOST_WORKDIR":"$CONTAINER_WORKDIR","$HOST_CONDA_ENVS_DIR":"$CONTAINER_CONDA_ENVS_DIR","$HOST_CACHEDIR":"/home/$USER/.cache","$HOST_CACHEDIR":/root/.cache,"$HOST_CACHEDIR":/home/root/.cache
 
-# use the conda environment that is activated at the host
-CONDA_ENV=$CONDA_DEFAULT_ENV
+# Define which conda environment should be activated. Set to $CONDA_DEFAULT_ENV, to use the one that is activated at
+# the host. If not defined, no conda environment will be activated and the base python interpreter will be used.
+# CONDA_ENV=$CONDA_DEFAULT_ENV
+
+# Define which pip requirements file should be used to install additional packages. If not defined, no additional
+# packages will be installed.
+PIP_REQUIREMENTS_FILE=requirements.txt
+
+# Define additional environment variables that should be set inside the container.
+# - NCCL_SOCKET_IFNAME and NCCL_IB_HCA are required for multi-node training with NCCL.
+# - PIP_INDEX_URL and PIP_TRUSTED_HOST are set to use the local PyPI cache of the DFKI cluster.
+# - PIP_NO_CACHE=true disables pip's default cache (we already use the fast local cache)
+# - PIP_REQUIREMENTS_FILE and CONDA_ENV are defined above.
+EXPORT="NCCL_SOCKET_IFNAME=bond,NCCL_IB_HCA=mlx5,PIP_INDEX_URL=http://pypi-cache/index,PIP_TRUSTED_HOST=pypi-cache,PIP_NO_CACHE=true,PIP_REQUIREMENTS_FILE=$PIP_REQUIREMENTS_FILE,CONDA_ENV=$CONDA_ENV"

--- a/.env.example
+++ b/.env.example
@@ -36,11 +36,11 @@ CONTAINER_MOUNTS=/netscratch:/netscratch,/ds:/ds:ro,"$HOST_WORKDIR":"$CONTAINER_
 
 # Define which conda environment should be activated. Set to $CONDA_DEFAULT_ENV, to use the one that is activated at
 # the host. If not defined, no conda environment will be activated and the base python interpreter will be used.
-# CONDA_ENV=$CONDA_DEFAULT_ENV
+CONDA_ENV=$CONDA_DEFAULT_ENV
 
 # Define which pip requirements file should be used to install additional packages. If not defined, no additional
 # packages will be installed.
-PIP_REQUIREMENTS_FILE=requirements.txt
+# PIP_REQUIREMENTS_FILE=requirements.txt
 
 # Define additional environment variables that should be set inside the container.
 # - NCCL_SOCKET_IFNAME and NCCL_IB_HCA are required for multi-node training with NCCL.

--- a/activate_and_execute.sh
+++ b/activate_and_execute.sh
@@ -13,6 +13,9 @@ if [ -n "$CONDA_ENV" ]; then
     conda activate $CONDA_ENV
 fi
 
+PYTHON_VERSION=$(python --version)
+echo "PYTHON VERSION: $PYTHON_VERSION"
+
 # if the variable PIP_REQUIREMENTS_FILE is defined, install the requirements
 if [ -n "$PIP_REQUIREMENTS_FILE" ]; then
     echo "install pip requirements from $PIP_REQUIREMENTS_FILE"

--- a/activate_and_execute.sh
+++ b/activate_and_execute.sh
@@ -2,17 +2,22 @@
 
 SCRIPT_DIR=$(dirname $0)
 
-# use first argument as conda environment name
-CONDA_ENV=$1
-shift
-
 # backup arguments and clear them (the source command fails otherwise)
 ARGS=( "$@" )
 shift $#
 
-echo "activate conda environment: $CONDA_ENV"
-source /opt/conda/bin/activate
-conda activate $CONDA_ENV
+# activate conda environment, if the variable is defined
+if [ -n "$CONDA_ENV" ]; then
+    echo "activate conda environment: $CONDA_ENV"
+    source /opt/conda/bin/activate
+    conda activate $CONDA_ENV
+fi
+
+# if the variable PIP_REQUIREMENTS_FILE is defined, install the requirements
+if [ -n "$PIP_REQUIREMENTS_FILE" ]; then
+    echo "install pip requirements from $PIP_REQUIREMENTS_FILE"
+    pip install -r "$PIP_REQUIREMENTS_FILE"
+fi
 
 # check for gpu availability
 python "$SCRIPT_DIR"/check_cuda.py

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -14,11 +14,11 @@ else
 fi
 
 # import and check required environment variables
-. "$SCRIPT_DIR"/import_vars.sh "$ENV_FILE" "CONTAINER_IMAGE" "PARTITION" "RESOURCE_ALLOCATION" "CONTAINER_WORKDIR" "CONTAINER_MOUNTS" "CONDA_ENV"
+. "$SCRIPT_DIR"/import_vars.sh "$ENV_FILE" "CONTAINER_IMAGE" "PARTITION" "RESOURCE_ALLOCATION" "CONTAINER_WORKDIR" "CONTAINER_MOUNTS" "EXPORT"
 
 srun -K -p $PARTITION $RESOURCE_ALLOCATION \
     --container-image="$CONTAINER_IMAGE" \
     --container-workdir="$CONTAINER_WORKDIR" \
     --container-mounts="$CONTAINER_MOUNTS","$SCRIPT_DIR":"$SCRIPT_DIR" \
-    --export="NCCL_SOCKET_IFNAME=bond,NCCL_IB_HCA=mlx5" \
-    bash "$SCRIPT_DIR"/activate_and_execute.sh "$CONDA_ENV" $*
+    --export="$EXPORT" \
+    bash "$SCRIPT_DIR"/activate_and_execute.sh $*


### PR DESCRIPTION
... install packages from a requirements file if `PIP_REQUIREMENTS_FILE` is set; export all vars defined in the `EXPORT` variable; set defaults: use Cluster-PyPi cache, no conda env, install deps from requirements.txt (see `.env.example` for details)