### PR TITLE
fix `.env.example` file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,19 @@
 # Edit these variables according to your need
 
-#CONTAINER_IMAGE=/netscratch/enroot/nvcr.io_nvidia_pytorch_21.10-py3.sqsh
+# choose an Enroot Image
+# IMPORTANT: For the scripts provided here to function correctly, there needs to be conda installed in that image!
 CONTAINER_IMAGE=/netscratch/enroot/nvcr.io_nvidia_pytorch_23.07-py3.sqsh
-#PARTITION=RTXA6000-SLT
-#PARTITION=A100-PCI
-#PARTITION=A100-40GB
-#PARTITION=V100-16GB
-#PARTITION=V100-32GB
+
+# chooses a Slurm partition
 PARTITION=batch
 #PARTITION=RTXA6000-SLT
-#PARTITION=RTX6000
-#PARTITION=RTX3090
-#PARTITION=A100-IML
-#PARTITION=H100-SLT
 
 # set the max time limit for the job
 # the general format to be used is d-hh:mm:ss
 # you can ignore the mm:ss to only set the number of days and hours
 MAX_TIME_LIMIT=3-0
 
-# resource allocation
+# resource allocation (RESOURCE_ALLOCATION):
 N_TASK=1
 GPUS_PER_TASK=1
 CPUS_PER_GPU=16

--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,6 @@ CPUS_PER_GPU=16
 MEMORY_PER_CPU=4G
 # assemble everything (feel free to modify this):
 RESOURCE_ALLOCATION="--ntasks=$N_TASK --gpus-per-task=$GPUS_PER_TASK --cpus-per-gpu=$CPUS_PER_GPU --mem-per-cpu=$MEMORY_PER_CPU"
-#RESOURCE_ALLOCATION="--ntasks=$N_TASK --gpus-per-task=$GPUS_PER_TASK --cpus-per-gpu=$CPUS_PER_GPU --mem=24G"
 
 # use the current working directory as the working directory inside the container
 CONTAINER_WORKDIR=`pwd`
@@ -58,4 +57,3 @@ JOB_NAME=$CONDA_ENV
 # - PIP_NO_CACHE=true disables pip's default cache (we already use the fast local cache)
 # - PIP_REQUIREMENTS_FILE and CONDA_ENV are defined above.
 EXPORT="NCCL_SOCKET_IFNAME=bond,NCCL_IB_HCA=mlx5,PIP_INDEX_URL=http://pypi-cache/index,PIP_TRUSTED_HOST=pypi-cache,PIP_NO_CACHE=true,PIP_REQUIREMENTS_FILE=$PIP_REQUIREMENTS_FILE,CONDA_ENV=$CONDA_ENV"
-

--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,32 @@
 # Edit these variables according to your need
 
-# choose an Enroot Image
-# IMPORTANT: For the scripts provided here to function correctly, there needs to be conda installed in that image!
+#CONTAINER_IMAGE=/netscratch/enroot/nvcr.io_nvidia_pytorch_21.10-py3.sqsh
 CONTAINER_IMAGE=/netscratch/enroot/nvcr.io_nvidia_pytorch_23.07-py3.sqsh
-
-# chooses a Slurm partition
-PARTITION=RTXA6000-SLT
+#PARTITION=RTXA6000-SLT
+#PARTITION=A100-PCI
+#PARTITION=A100-40GB
+#PARTITION=V100-16GB
+#PARTITION=V100-32GB
+PARTITION=batch
+#PARTITION=RTXA6000-SLT
+#PARTITION=RTX6000
+#PARTITION=RTX3090
+#PARTITION=A100-IML
+#PARTITION=H100-SLT
 
 # set the max time limit for the job
 # the general format to be used is d-hh:mm:ss
 # you can ignore the mm:ss to only set the number of days and hours
 MAX_TIME_LIMIT=3-0
 
-# resource allocation (RESOURCE_ALLOCATION):
+# resource allocation
 N_TASK=1
 GPUS_PER_TASK=1
-CPUS_PER_GPU=4
+CPUS_PER_GPU=16
 MEMORY_PER_CPU=4G
 # assemble everything (feel free to modify this):
 RESOURCE_ALLOCATION="--ntasks=$N_TASK --gpus-per-task=$GPUS_PER_TASK --cpus-per-gpu=$CPUS_PER_GPU --mem-per-cpu=$MEMORY_PER_CPU"
+#RESOURCE_ALLOCATION="--ntasks=$N_TASK --gpus-per-task=$GPUS_PER_TASK --cpus-per-gpu=$CPUS_PER_GPU --mem=24G"
 
 # use the current working directory as the working directory inside the container
 CONTAINER_WORKDIR=`pwd`
@@ -56,3 +64,4 @@ JOB_NAME=$CONDA_ENV
 # - PIP_NO_CACHE=true disables pip's default cache (we already use the fast local cache)
 # - PIP_REQUIREMENTS_FILE and CONDA_ENV are defined above.
 EXPORT="NCCL_SOCKET_IFNAME=bond,NCCL_IB_HCA=mlx5,PIP_INDEX_URL=http://pypi-cache/index,PIP_TRUSTED_HOST=pypi-cache,PIP_NO_CACHE=true,PIP_REQUIREMENTS_FILE=$PIP_REQUIREMENTS_FILE,CONDA_ENV=$CONDA_ENV"
+


### PR DESCRIPTION
This increases `CPUS_PER_GPU` from `4` to `16`. It is super strange, but the setup fails with just 4 cpus per gpu.

Also, this changes the default `PARTITION` to `batch` because this increases the startup time dramatically which is good to get the setup initially running. Note that for the real training setting, this needs to be set to a valid partition!