### PR TITLE
Conda install and paths update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 
 # choose an Enroot Image
 # IMPORTANT: For the scripts provided here to function correctly, there needs to be conda installed in that image!
-CONTAINER_IMAGE=/netscratch/enroot/nvcr.io_nvidia_pytorch_23.07-py3.sqsh
+CONTAINER_IMAGE=/enroot/nvcr.io_nvidia_pytorch_23.07-py3.sqsh
 
 # chooses a Slurm partition
 PARTITION=batch
@@ -38,7 +38,7 @@ HOST_CONDA_ENVS_DIR=/netscratch/$USER/miniconda3
 # change this if you use another Enroot image with a different conda location
 CONTAINER_CONDA_ENVS_DIR=/opt/conda
 # assemble everything:
-CONTAINER_MOUNTS=/netscratch:/netscratch,/ds:/ds:ro,"$HOST_WORKDIR":"$CONTAINER_WORKDIR","$HOST_CONDA_ENVS_DIR":"$CONTAINER_CONDA_ENVS_DIR","$HOST_CACHEDIR":"/home/$USER/.cache","$HOST_CACHEDIR":/root/.cache,"$HOST_CACHEDIR":/home/root/.cache
+CONTAINER_MOUNTS=/netscratch:/netscratch,/fscratch/$USER:/fscratch/$USER,/ds:/ds:ro,"$HOST_WORKDIR":"$CONTAINER_WORKDIR","$HOST_CONDA_ENVS_DIR":"$CONTAINER_CONDA_ENVS_DIR","$HOST_CACHEDIR":"/home/$USER/.cache","$HOST_CACHEDIR":/root/.cache,"$HOST_CACHEDIR":/home/root/.cache
 
 # Define which conda environment should be activated. Set to $CONDA_DEFAULT_ENV, to use the one that is activated at
 # the host. If not defined, no conda environment will be activated and the base python interpreter will be used.

--- a/activate_and_execute.sh
+++ b/activate_and_execute.sh
@@ -6,6 +6,28 @@ SCRIPT_DIR=$(dirname $0)
 ARGS=( "$@" )
 shift $#
 
+if ! command -v conda > /dev/null 2>&1; then
+    echo "Installing conda..."
+    #wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O ~/miniconda.sh
+    #bash ~/miniconda.sh -b -p $HOME/miniconda
+    # Following https://docs.conda.io/projects/conda/en/latest/user-guide/install/rpm-debian.html
+    # Install our public GPG key to trusted store
+    curl https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg --dearmor > conda.gpg
+    install -o root -g root -m 644 conda.gpg /usr/share/keyrings/conda-archive-keyring.gpg
+    # Check whether fingerprint is correct (will output an error message otherwise)
+    gpg --keyring /usr/share/keyrings/conda-archive-keyring.gpg --no-default-keyring --fingerprint 34161F5BF5EB1D4BFBBB8F0A8AEB4F8B29D82806
+    # Add our Debian repo
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/conda-archive-keyring.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" > /etc/apt/sources.list.d/conda.list
+    apt update
+    apt install conda
+    source /opt/conda/etc/profile.d/conda.sh
+    conda -V
+    echo "channels:" > /opt/conda/.condarc
+    echo "  - conda-forge" >> /opt/conda/.condarc
+    echo "channel_priority: strict" >> /opt/conda/.condarc
+fi
+
+
 # activate conda environment, if the variable is defined
 if [ -n "$CONDA_ENV" ]; then
     echo "activate conda environment: $CONDA_ENV"

--- a/activate_and_execute.sh
+++ b/activate_and_execute.sh
@@ -7,10 +7,8 @@ ARGS=( "$@" )
 shift $#
 
 if ! command -v conda > /dev/null 2>&1; then
-    echo "Installing conda..."
-    #wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O ~/miniconda.sh
-    #bash ~/miniconda.sh -b -p $HOME/miniconda
     # Following https://docs.conda.io/projects/conda/en/latest/user-guide/install/rpm-debian.html
+    echo "Installing conda..."
     # Install our public GPG key to trusted store
     curl https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg --dearmor > conda.gpg
     install -o root -g root -m 644 conda.gpg /usr/share/keyrings/conda-archive-keyring.gpg

--- a/activate_and_execute.sh
+++ b/activate_and_execute.sh
@@ -18,10 +18,9 @@ if ! command -v conda > /dev/null 2>&1; then
     gpg --keyring /usr/share/keyrings/conda-archive-keyring.gpg --no-default-keyring --fingerprint 34161F5BF5EB1D4BFBBB8F0A8AEB4F8B29D82806
     # Add our Debian repo
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/conda-archive-keyring.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" > /etc/apt/sources.list.d/conda.list
-    apt update
-    apt install conda
+    apt -qy update
+    apt -qy install conda
     source /opt/conda/etc/profile.d/conda.sh
-    conda -V
     echo "channels:" > /opt/conda/.condarc
     echo "  - conda-forge" >> /opt/conda/.condarc
     echo "channel_priority: strict" >> /opt/conda/.condarc

--- a/activate_and_execute.sh
+++ b/activate_and_execute.sh
@@ -16,8 +16,8 @@ if ! command -v conda > /dev/null 2>&1; then
     gpg --keyring /usr/share/keyrings/conda-archive-keyring.gpg --no-default-keyring --fingerprint 34161F5BF5EB1D4BFBBB8F0A8AEB4F8B29D82806
     # Add our Debian repo
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/conda-archive-keyring.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" > /etc/apt/sources.list.d/conda.list
-    apt -qy update
-    apt -qy install conda
+    apt update
+    apt install conda
     source /opt/conda/etc/profile.d/conda.sh
     echo "channels:" > /opt/conda/.condarc
     echo "  - conda-forge" >> /opt/conda/.condarc


### PR DESCRIPTION
Addresses issue #11 and also adds a conda install if conda is not available within the enroot image. Conda config is set to use conda-forge as the only channel